### PR TITLE
Add Firestore seeding script and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@
 - GitHub workflows expect a static build in `da-box-v2/out` and use Node.js 20.
 - Copy `.env.example` to `.env` and fill in your Firebase credentials if running locally.
 - Add repository secrets for each Firebase variable so CI builds use the same credentials.
+- To seed Firestore with defaults, set `GOOGLE_APPLICATION_CREDENTIALS` and run `npm run setup-firestore` from `da-box-v2`. Use `INIT_ADMIN_EMAIL` and `INIT_ADMIN_PASSWORD` to create an initial admin user.

--- a/da-box-v2/README.md
+++ b/da-box-v2/README.md
@@ -53,11 +53,24 @@ Global configuration like `relayHoldTime` and `inactivityTimeout` is saved in `g
 
 ### Initializing Firestore
 
-If your Firestore database is empty, you can create the default `globalSettings` document by running:
+If your Firestore database is empty, you can create the default data by running one of the provided scripts. Both scripts require Firebase service account credentials. Set the path to your JSON key using the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+
+To only create `globalSettings/settings` with default configuration run:
 
 ```bash
 export GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccountKey.json
-node ../scripts/initFirestore.js
+npm run init-firestore
 ```
 
-This script uses the Firebase Admin SDK to create `globalSettings/settings` with sensible defaults. It only runs once and will not overwrite an existing document.
+This script creates `globalSettings/settings` with sensible defaults. It only runs once and will not overwrite an existing document.
+
+You can also seed an initial admin user and the same settings in one go:
+
+```bash
+export GOOGLE_APPLICATION_CREDENTIALS=path/to/serviceAccountKey.json
+export INIT_ADMIN_EMAIL=admin@example.com
+export INIT_ADMIN_PASSWORD=supersecret
+npm run setup-firestore
+```
+
+`setup-firestore` will create the admin authentication account and a matching document in `users/<uid>` with the role set to `admin` if they don't already exist. The global settings document is created as well if missing.

--- a/da-box-v2/package.json
+++ b/da-box-v2/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "init-firestore": "node ../scripts/initFirestore.js"
+    "init-firestore": "node ../scripts/initFirestore.js",
+    "setup-firestore": "node ../scripts/setupFirestore.js"
   },
   "dependencies": {
     "firebase": "^11.9.0",

--- a/scripts/setupFirestore.js
+++ b/scripts/setupFirestore.js
@@ -1,0 +1,57 @@
+const { initializeApp, applicationDefault } = require('firebase-admin/app');
+const { getFirestore } = require('firebase-admin/firestore');
+const { getAuth } = require('firebase-admin/auth');
+
+initializeApp({ credential: applicationDefault() });
+const db = getFirestore();
+const auth = getAuth();
+
+async function ensureGlobalSettings() {
+  const settingsRef = db.collection('globalSettings').doc('settings');
+  const docSnap = await settingsRef.get();
+  if (!docSnap.exists) {
+    await settingsRef.set({
+      relayHoldTime: 5000,
+      inactivityTimeout: 300000,
+      lockState: 'locked'
+    });
+    console.log('Created globalSettings/settings with defaults');
+  } else {
+    console.log('globalSettings/settings already exists');
+  }
+}
+
+async function ensureAdminUser() {
+  const email = process.env.INIT_ADMIN_EMAIL;
+  const password = process.env.INIT_ADMIN_PASSWORD;
+  if (!email || !password) {
+    console.log('Skipping admin user creation: INIT_ADMIN_EMAIL or INIT_ADMIN_PASSWORD not set');
+    return;
+  }
+  let user;
+  try {
+    user = await auth.getUserByEmail(email);
+    console.log('Admin user already exists:', email);
+  } catch (err) {
+    user = await auth.createUser({ email, password });
+    console.log('Created admin auth user:', email);
+  }
+  const userRef = db.collection('users').doc(user.uid);
+  const userSnap = await userRef.get();
+  if (!userSnap.exists) {
+    await userRef.set({ email, role: 'admin' });
+    console.log('Created admin Firestore document');
+  } else {
+    console.log('Admin Firestore document already exists');
+  }
+}
+
+async function main() {
+  await ensureGlobalSettings();
+  await ensureAdminUser();
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- document how to seed Firestore in README
- add `setup-firestore` script to create the global settings and an admin user
- mention seeding step in agent instructions

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a173a290c83298f00c4a625fa322d